### PR TITLE
Update catalog.json with ui5-manifest url from SAP

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1617,10 +1617,17 @@
     },
     {
       "name": "ui5-manifest",
-      "description": "UI5 manifest file",
+      "description": "UI5/OPENUI5 descriptor file",
       "fileMatch": [
-        "manifest.json",
         ".manifest"
+      ],
+      "url": "https://json.schemastore.org/ui5-manifest"
+    },
+    {
+      "name": "manifest.json",
+      "description": "UI5 manifest (manifest.json)",
+      "fileMatch": [
+        "manifest.json"
       ],
       "url": "https://raw.githubusercontent.com/SAP/ui5-manifest/master/schema.json"
     },

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1617,11 +1617,12 @@
     },
     {
       "name": "ui5-manifest",
-      "description": "UI5/OPENUI5 descriptor file",
+      "description": "UI5 manifest file",
       "fileMatch": [
+        "manifest.json",
         ".manifest"
       ],
-      "url": "https://json.schemastore.org/ui5-manifest"
+      "url": "https://raw.githubusercontent.com/SAP/ui5-manifest/master/schema.json"
     },
     {
       "name": "ui5.yaml",

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1627,7 +1627,8 @@
       "name": "UI5 Manifest",
       "description": "UI5 Manifest (manifest.json)",
       "fileMatch": [
-        "manifest.json"
+        "webapp/manifest.json",
+        "src/main/webapp/manifest.json"
       ],
       "url": "https://raw.githubusercontent.com/SAP/ui5-manifest/master/schema.json"
     },

--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -1624,8 +1624,8 @@
       "url": "https://json.schemastore.org/ui5-manifest"
     },
     {
-      "name": "manifest.json",
-      "description": "UI5 manifest (manifest.json)",
+      "name": "UI5 Manifest",
+      "description": "UI5 Manifest (manifest.json)",
       "fileMatch": [
         "manifest.json"
       ],


### PR DESCRIPTION
We are now hosting the schema for the UI5  manifest in SAP github.
Therefore adding new entry in catalog.json pointing to that URL with pattern "manifest.json" as this is the file name for the UI5 manifest.